### PR TITLE
Feat: Add namespace output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "name" {
   value       = kubernetes_secret.docker.metadata[0].name
 }
 
+output "namespace" {
+  description = "The namespace of the secret"
+  value       = kubernetes_secret.docker.metadata[0].namespace
+}
+
 output "data" {
   description = "The secret data"
   value       = kubernetes_secret.docker.data


### PR DESCRIPTION
Changes:
- Adds the secret namespace as output

Reasoning:
When creating a service account to use this secret, the secret has to live in the same namespace that the service account does. Using the secret's namespace output in the service account definition allows the developer to couple the resources in a way that could prevent using the wrong namespace by accident. 